### PR TITLE
Updated workspace to apply prettier formatting on .ts and .tsx files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,15 @@
     "source.fixAll": "explicit"
   },
   "files.eol": "\n",
-  "files.insertFinalNewline": true
+  "files.insertFinalNewline": true,
+  "prettier.jsxSingleQuote": true,
+  "prettier.singleQuote": true,
+  "typescript.preferences.quoteStyle": "single",
+  "javascript.preferences.quoteStyle": "single",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,5 @@
 // Admin homepage - have to get "Admin" role in auth0
-import React from "react";
+import React from 'react';
 
 export default function Admin() {
   return (

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,13 +1,13 @@
 // app\layout.tsx
-import type { Metadata } from "next";
-import NavBar from "@/components/Navbar/Navbar";
-import "./globals.css";
-import { Providers } from "./providers";
-import { UserProvider } from "@auth0/nextjs-auth0/client";
+import type { Metadata } from 'next';
+import NavBar from '@/components/Navbar/Navbar';
+import './globals.css';
+import { Providers } from './providers';
+import { UserProvider } from '@auth0/nextjs-auth0/client';
 
 export const metadata: Metadata = {
-  title: "CourseMetrics",
-  description: "PRJ666 Final Project",
+  title: 'CourseMetrics',
+  description: 'PRJ666 Final Project',
 };
 
 export default function RootLayout({
@@ -16,9 +16,9 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang='en'>
       <UserProvider>
-        <body className="bg-[#0B2027] text-white min-h-screen">
+        <body className='bg-[#0B2027] text-white min-h-screen'>
           <Providers>
             <NavBar />
             {children}


### PR DESCRIPTION
This is to address issue #8.

This commit applies the fix to the following issues:
1. [x] `.ts` files aren't being formatted using `Prettier` at all.
2. [x] There are inconsistencies with the use of single quotes and double quotes for `.ts` files and `.tsx` files.
3. [x] Updating existing `.tsx` files to use the standardized formatting.