### PR TITLE
workspace settings now ensure `rpath` produces the filepath of a file

### DIFF
--- a/.vscode/javascript.code-snippets
+++ b/.vscode/javascript.code-snippets
@@ -1,0 +1,7 @@
+{
+  "Insert Current File Path Comment": {
+    "prefix": "rpath",
+    "body": ["// ${RELATIVE_FILEPATH/[\\\\]/\\//g}"],
+    "description": "Inserts a comment with the relative path of the current file"
+  }
+}

--- a/.vscode/javascriptreact.code-snippets
+++ b/.vscode/javascriptreact.code-snippets
@@ -1,0 +1,7 @@
+{
+  "Insert Current File Path Comment": {
+    "prefix": "rpath",
+    "body": ["// ${RELATIVE_FILEPATH/[\\\\]/\\//g}"],
+    "description": "Inserts a comment with the relative path of the current file"
+  }
+}

--- a/.vscode/typescript.code-snippets
+++ b/.vscode/typescript.code-snippets
@@ -1,0 +1,7 @@
+{
+  "Insert Current File Path Comment": {
+    "prefix": "rpath",
+    "body": ["// ${RELATIVE_FILEPATH/[\\\\]/\\//g}"],
+    "description": "Inserts a comment with the relative path of the current file"
+  }
+}

--- a/.vscode/typescriptreact.code-snippets
+++ b/.vscode/typescriptreact.code-snippets
@@ -1,0 +1,7 @@
+{
+  "Insert Current File Path Comment": {
+    "prefix": "rpath",
+    "body": ["// ${RELATIVE_FILEPATH/[\\\\]/\\//g}"],
+    "description": "Inserts a comment with the relative path of the current file"
+  }
+}

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,3 +1,4 @@
+// app/about/page.tsx
 const About = () => {
   return <div>about</div>;
 };

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,3 +1,4 @@
+// app/admin/page.tsx
 // Admin homepage - have to get "Admin" role in auth0
 import React from 'react';
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-// app\layout.tsx
+// app/layout.tsx
 import type { Metadata } from 'next';
 import NavBar from '@/components/Navbar/Navbar';
 import './globals.css';

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,4 @@
-// app\page.tsx
-
+// app/page.tsx
 import React from 'react';
 
 export default function Home() {


### PR DESCRIPTION
This closes issue #11.

`rpath` now produces a comment containing the relative path of a `.js`, `.ts`, `.jsx`, and `.tsx` file.

The updates to the workspace settings ensures that Windows, Linux, and Mac users receive the same output for the same code snippet.

![image](https://github.com/user-attachments/assets/32b3a3ab-9ebb-4012-b3d6-16a3b4b21d80)
