### PR TITLE
feat(navbar): add conditional logic for Sign In vs. Sign Out

### DIFF
--- a/components/Navbar/MainNav.tsx
+++ b/components/Navbar/MainNav.tsx
@@ -173,7 +173,7 @@ const DesktopNav = ({ position }: { position: string }) => {
         }
 
         return (
-          <Box key={navItem.label}>
+          <Box key={navItem.label} className="px-2 whitespace-nowrap">
             <Popover trigger={'hover'} placement={'bottom-start'}>
               <PopoverTrigger>
                 <Link href={navItem.href ?? '#'}>


### PR DESCRIPTION
Added the conditional logic so that:
1. `Sign In` will show only if the user is signed out.
![sign-in](https://github.com/user-attachments/assets/2815aeda-8ad6-4f05-8854-fe3269c794f6)


3. `Sign Out` will show only if the user is signed in.
![sign-out](https://github.com/user-attachments/assets/2475a8cd-d3f0-47a6-a2f7-bc7b8aa9d6a4)

This is progress towards issue #38. 

