### PR TITLE
Add Frontend of Prof and Review for Admin Dashboard

### DIFF
--- a/app/admin/manage/page.tsx
+++ b/app/admin/manage/page.tsx
@@ -12,8 +12,10 @@ import {
 } from '@chakra-ui/react';
 import { useState } from 'react';
 import CoursesTable from '@/components/CoursesTable'; // Import the new component
+import ProfessorsTable from '@/components/ProfessorsTable'; // Import the new component
+import ReviewsTable from '@/components/ReviewsTable'; // Import the new component
 
-// Sample data for courses
+// ************************************************** SAMPLE DATA TO BE REMOVED WHEN BACKEND FINISH **************************************************
 const courses = [
   {
     name: 'Course 1',
@@ -59,8 +61,110 @@ const courses = [
     description:
       'Data Structures and Algorithms. This course will cover advanced topics and practical applications.',
   },
-  // Add more courses as needed
 ];
+
+const professors = [
+  {
+    first_name: 'John',
+    last_name: 'Doe',
+  },
+  {
+    first_name: 'Jane',
+    last_name: 'Smith',
+  },
+  {
+    first_name: 'Emily',
+    last_name: 'Johnson',
+  },
+  {
+    first_name: 'Michael',
+    last_name: 'Brown',
+  },
+  {
+    first_name: 'Sarah',
+    last_name: 'Davis',
+  },
+  {
+    first_name: 'John',
+    last_name: 'Doe',
+  },
+  {
+    first_name: 'Jane',
+    last_name: 'Smith',
+  },
+  {
+    first_name: 'Emily',
+    last_name: 'Johnson',
+  },
+  {
+    first_name: 'Michael',
+    last_name: 'Brown',
+  },
+  {
+    first_name: 'Sarah',
+    last_name: 'Davis',
+  },
+];
+
+const reviews = [
+  {
+    category: 'Course Review',
+    course_code: 'CSC101',
+    review_text:
+      'This course provides a solid introduction to computer science, with a focus on programming fundamentals. Highly recommended for beginners!',
+    average_rate: 4.5,
+    status: 'approved',
+  },
+  {
+    category: 'Course Review',
+    course_code: 'MTH202',
+    review_text:
+      'The content was quite challenging, but the professor was very helpful. I struggled with some concepts, but overall, it was a good learning experience.',
+    average_rate: 3.8,
+    status: 'pending',
+  },
+  {
+    category: 'Professor Review',
+    course_code: 'PHY303',
+    review_text:
+      'Professor Smith explains difficult concepts clearly and is always available to answer questions. However, the exams were much harder than expected.',
+    average_rate: 4.2,
+    status: 'approved',
+  },
+  {
+    category: 'Course Review',
+    course_code: 'ENG104',
+    review_text:
+      'I didn’t enjoy the lectures, but the assignments were interesting. The course material felt outdated, and there was little class interaction.',
+    average_rate: 2.5,
+    status: 'rejected',
+  },
+  {
+    category: 'Professor Review',
+    course_code: 'CHE201',
+    review_text:
+      'Dr. Thompson is a brilliant professor but can be very strict. If you want to succeed in this class, you need to work hard and follow all the guidelines.',
+    average_rate: 4.0,
+    status: 'pending',
+  },
+  {
+    category: 'Course Review',
+    course_code: 'CSC101',
+    review_text:
+      'This course provides a solid introduction to computer science, with a focus on programming fundamentals. Highly recommended for beginners!',
+    average_rate: 4.5,
+    status: 'approved',
+  },
+  {
+    category: 'Course Review',
+    course_code: 'MTH202',
+    review_text:
+      'The content was quite challenging, but the professor was very helpful. I struggled with some concepts, but overall, it was a good learning experience.',
+    average_rate: 3.8,
+    status: 'pending',
+  },
+];
+// ******************************************************************************************************************************************************************
 
 export default function Manage() {
   const [selectedOption, setSelectedOption] = useState<string>('');
@@ -74,14 +178,39 @@ export default function Manage() {
     setSearchValue(event.target.value);
   };
 
+  // ************************************************** FILTER SAMPLE DATA TO BE CHANGED WITH DB DATA **************************************************
+
   // Function to filter courses based on search value
   const filteredCourses = courses.filter(
     (course) =>
-      course.name.toLowerCase().includes(searchValue.toLowerCase()) || // Search by course name
-      course.section.toLowerCase().includes(searchValue.toLowerCase()) || // Search by section
-      course.term.toLowerCase().includes(searchValue.toLowerCase()) || // Search by term
-      course.description.toLowerCase().includes(searchValue.toLowerCase()) // Search by description
+      course.name.toLowerCase().includes(searchValue.toLowerCase()) ||
+      course.section.toLowerCase().includes(searchValue.toLowerCase()) ||
+      course.term.toLowerCase().includes(searchValue.toLowerCase()) ||
+      course.description.toLowerCase().includes(searchValue.toLowerCase())
   );
+
+  const filteredProfessors = professors.filter((professor) => {
+    const fullName = `${professor.first_name} ${professor.last_name}`.toLowerCase();
+    return (
+      professor.first_name.toLowerCase().includes(searchValue.toLowerCase()) ||
+      professor.last_name.toLowerCase().includes(searchValue.toLowerCase()) ||
+      fullName.includes(searchValue.toLowerCase())
+    );
+  });
+
+  // Function to filter reviews based on search value
+  const filteredReviews = reviews.filter((review) => {
+    const normalizedRate = review.average_rate.toFixed(1); // Keep one decimal place
+    return (
+      review.review_text.toLowerCase().includes(searchValue.toLowerCase()) ||
+      review.category.toLowerCase().includes(searchValue.toLowerCase()) ||
+      review.course_code.toLowerCase().includes(searchValue.toLowerCase()) ||
+      review.status.toLowerCase().includes(searchValue.toLowerCase()) ||
+      normalizedRate.includes(searchValue)
+    );
+  });
+
+  // ******************************************************************************************************************************************************************
 
   return (
     <Box p={4}>
@@ -129,8 +258,10 @@ export default function Manage() {
       </Flex>
 
       <Divider mb={4} />
-      {/* Conditionally render the CoursesTable when "courses" is selected */}
-      {selectedOption === 'courses' && <CoursesTable courses={courses} />}
+      {/* Conditionally render appropriate category when it is selected */}
+      {selectedOption === 'courses' && <CoursesTable courses={filteredCourses} />}
+      {selectedOption === 'professors' && <ProfessorsTable professors={filteredProfessors} />}
+      {selectedOption === 'reviews' && <ReviewsTable reviews={filteredReviews} />}
     </Box>
   );
 }

--- a/components/ProfessorsTable.tsx
+++ b/components/ProfessorsTable.tsx
@@ -1,0 +1,94 @@
+import { Box, Flex, Stack, Text, Button } from '@chakra-ui/react';
+
+// Define the Professor type
+type Professor = {
+  first_name: string;
+  last_name: string;
+};
+
+// Props interface
+interface ProfessorsTableProps {
+  professors: Professor[];
+}
+
+const ProfessorsTable: React.FC<ProfessorsTableProps> = ({ professors }) => {
+  return (
+    <>
+      {/* Table Header */}
+      <Flex
+        bg="gray.50"
+        p={2}
+        borderRadius="md"
+        justify="space-between"
+        fontWeight="bold"
+        color="black"
+        align="center"
+      >
+        <Text flex="5" textAlign="left">
+          Professor Name
+        </Text>
+        <Text flex="1" textAlign="left">
+          Options
+        </Text>
+      </Flex>
+
+      {/* Scrollable Stack Container */}
+      <Box
+        mt={4}
+        maxHeight="65vh"
+        overflowY="auto"
+        p={2}
+        css={{
+          '&::-webkit-scrollbar': {
+            width: '6px',
+          },
+          '&::-webkit-scrollbar-track': {
+            background: '#f1f1f1',
+          },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: '#888',
+            borderRadius: '10px',
+          },
+          '&::-webkit-scrollbar-thumb:hover': {
+            background: '#555',
+          },
+        }}
+      >
+        <Stack spacing={4}>
+          {professors.map((professor, index) => (
+            <Box key={index} borderWidth="1px" borderRadius="lg" padding={4} bg="gray.50">
+              <Flex justify="space-between" align="center">
+                {/* Concatenate first name and last name */}
+                <Text flex="5" color="black" m={1}>
+                  {`${professor.first_name} ${professor.last_name}`}
+                </Text>
+                <Flex
+                  flexDirection={{ base: 'column', md: 'row' }}
+                  justifyContent="space-between"
+                  m={1}
+                  gap={4}
+                  flex="1"
+                >
+                  <Button
+                    colorScheme="teal"
+                    color="white"
+                    flex="1"
+                    mr={{ base: 0, md: 1 }}
+                    mb={{ base: 1, md: 0 }}
+                  >
+                    View Details
+                  </Button>
+                  <Button colorScheme="teal" color="white" flex="1" ml={{ base: 0, md: 1 }}>
+                    Remove
+                  </Button>
+                </Flex>
+              </Flex>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </>
+  );
+};
+
+export default ProfessorsTable;

--- a/components/ReviewsTable.tsx
+++ b/components/ReviewsTable.tsx
@@ -1,0 +1,155 @@
+import { Box, Flex, Stack, Text, Button, Icon } from '@chakra-ui/react';
+import { FaCheckCircle, FaTimesCircle, FaExclamationCircle } from 'react-icons/fa';
+
+// Define the Review type
+type Review = {
+  category: string;
+  course_code: string;
+  review_text: string;
+  average_rate: number;
+  status: string; // 'approved' | 'pending' | 'rejected'
+};
+
+// Props interface
+interface ReviewsTableProps {
+  reviews: Review[];
+}
+
+const ReviewsTable: React.FC<ReviewsTableProps> = ({ reviews }) => {
+  // Sort reviews by status ('pending' first)
+  const sortedReviews = [...reviews].sort((a, b) => {
+    if (a.status === 'pending' && b.status !== 'pending') return -1;
+    if (b.status === 'pending' && a.status !== 'pending') return 1;
+
+    // secondary sort
+    return b.average_rate - a.average_rate;
+  });
+
+  // Function to get the correct status icon
+  const getStatusIcon = (status: string) => {
+    switch (status) {
+      case 'approved':
+        return <Icon as={FaCheckCircle} color="green.500" boxSize="8" />;
+      case 'pending':
+        return <Icon as={FaExclamationCircle} color="yellow.500" boxSize="8" />;
+      case 'rejected':
+        return <Icon as={FaTimesCircle} color="red.500" boxSize="8" />;
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <>
+      {/* Table Header */}
+      <Flex
+        bg="gray.50"
+        p={2}
+        borderRadius="md"
+        justify="space-between"
+        fontWeight="bold"
+        color="black"
+        align="center"
+      >
+        <Text flex="1" textAlign="left">
+          Category
+        </Text>
+        <Text flex="1" textAlign="left">
+          Course Code
+        </Text>
+        <Text flex="2" textAlign="left">
+          Review
+        </Text>
+        <Text flex="1" textAlign="center">
+          Avg. Rating
+        </Text>
+        <Text flex="1" textAlign="left">
+          Options
+        </Text>
+        <Text flex="1" textAlign="center">
+          Status
+        </Text>
+      </Flex>
+
+      {/* Scrollable Stack Container */}
+      <Box
+        mt={4}
+        maxHeight="65vh"
+        overflowY="auto"
+        p={2}
+        css={{
+          '&::-webkit-scrollbar': {
+            width: '6px',
+          },
+          '&::-webkit-scrollbar-track': {
+            background: '#f1f1f1',
+          },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: '#888',
+            borderRadius: '10px',
+          },
+          '&::-webkit-scrollbar-thumb:hover': {
+            background: '#555',
+          },
+        }}
+      >
+        <Stack spacing={4}>
+          {sortedReviews.map((review, index) => (
+            <Box key={index} borderWidth="1px" borderRadius="lg" padding={4} bg="gray.50">
+              <Flex justify="space-between" align="center">
+                {/* Category */}
+                <Text flex="1" color="black" m={1}>
+                  {review.category}
+                </Text>
+
+                {/* Course Code */}
+                <Text flex="1" color="black" m={1}>
+                  {review.course_code}
+                </Text>
+
+                {/* Truncated Review */}
+                <Text flex="2" color="black" isTruncated m={1}>
+                  {review.review_text}
+                </Text>
+
+                {/* Average Rating */}
+                <Text flex="1" color="black" m={1} textAlign="center">
+                  {review.average_rate.toFixed(1)} / 5
+                </Text>
+
+                {/* Options Buttons */}
+                <Flex
+                  flexDirection={{ base: 'column', md: 'row' }}
+                  justifyContent="space-between"
+                  m={1}
+                  gap={4}
+                  flex="1"
+                >
+                  <Button
+                    colorScheme="teal"
+                    color="white"
+                    flex="1"
+                    mr={{ base: 0, md: 1 }}
+                    mb={{ base: 1, md: 0 }}
+                  >
+                    View Details
+                  </Button>
+                  <Button colorScheme="teal" color="white" flex="1" ml={{ base: 0, md: 1 }}>
+                    Remove
+                  </Button>
+                </Flex>
+
+                {/* Status Icon */}
+                <Text flex="1" textAlign="center" m={1}>
+                  {getStatusIcon(review.status)}
+                </Text>
+              </Flex>
+            </Box>
+          ))}
+        </Stack>
+      </Box>
+    </>
+  );
+};
+
+export default ReviewsTable;


### PR DESCRIPTION
## Add
- components/ProfessorsTable.tsx to get the list of professors
- components/ReviewsTable.tsx to get the list of reviews primarily sorted by pending reviews and secondary sorted by average rate.

## Update
- app/admin/manage/page.tsx to add the logic of the Professors and Reviews selection. The search input also works properly.

### This is the Frontend of the Professor Search Page:
![image](https://github.com/user-attachments/assets/0eff503d-0ce4-477f-872a-b9dee7ccef97)

### This is the Frontend of the Reviews Search Page:
![image](https://github.com/user-attachments/assets/635b374c-4b73-4e29-b875-f0f5d170acd5)

This currently use sample datas for the courses, professors, and reviews, until the API are ready.

This pull request is part of issue #62