### PR TITLE
fix(models): models have createdAt and updatedAt fields

### DIFF
--- a/models/ActionType.ts
+++ b/models/ActionType.ts
@@ -19,7 +19,7 @@ ActionType.init(
       unique: true,
     },
   },
-  { sequelize, tableName: 'action_types', timestamps: false }
+  { sequelize, tableName: 'action_types' }
 );
 
 export default ActionType;

--- a/models/AdminAction.ts
+++ b/models/AdminAction.ts
@@ -48,7 +48,7 @@ AdminAction.init(
       allowNull: false,
     },
   },
-  { sequelize, tableName: 'admin_actions', timestamps: false }
+  { sequelize, tableName: 'admin_actions' }
 );
 
 // Associations

--- a/models/Course.ts
+++ b/models/Course.ts
@@ -41,7 +41,7 @@ Course.init(
       allowNull: false,
     },
   },
-  { sequelize, tableName: 'courses', timestamps: false }
+  { sequelize, tableName: 'courses' }
 );
 
 // Associations

--- a/models/CourseDetail.ts
+++ b/models/CourseDetail.ts
@@ -12,7 +12,7 @@ CourseDetail.init(
     course_name: { type: DataTypes.STRING, allowNull: false },
     course_description: { type: DataTypes.STRING, allowNull: false },
   },
-  { sequelize, tableName: 'course_details', timestamps: false }
+  { sequelize, tableName: 'course_details' }
 );
 
 export default CourseDetail;

--- a/models/Policy.ts
+++ b/models/Policy.ts
@@ -12,7 +12,7 @@ Policy.init(
     policy_name: { type: DataTypes.STRING, allowNull: false },
     policy_description: { type: DataTypes.STRING, allowNull: false },
   },
-  { sequelize, tableName: 'policies', timestamps: false }
+  { sequelize, tableName: 'policies' }
 );
 
 export default Policy;

--- a/models/Professor.ts
+++ b/models/Professor.ts
@@ -20,13 +20,11 @@ Professor.init(
     last_name: {
       type: DataTypes.STRING,
       allowNull: false,
-      unique: true,
     },
   },
   {
     sequelize,
     tableName: 'professors',
-    timestamps: false,
   }
 );
 

--- a/models/ProfessorCourse.ts
+++ b/models/ProfessorCourse.ts
@@ -31,7 +31,6 @@ ProfessorCourse.init(
   {
     sequelize,
     tableName: 'professor_course',
-    timestamps: false,
   }
 );
 

--- a/models/Question.ts
+++ b/models/Question.ts
@@ -34,7 +34,6 @@ Question.init(
         model: ReviewType,
         key: 'review_type_id',
       },
-      field: 'review_type_id',
     },
   },
   { sequelize, tableName: 'questions', timestamps: false }

--- a/models/Review.ts
+++ b/models/Review.ts
@@ -49,7 +49,7 @@ Review.init(
       },
     },
   },
-  { sequelize, tableName: 'reviews', timestamps: false }
+  { sequelize, tableName: 'reviews' }
 );
 
 // Associations

--- a/models/ReviewAnswer.ts
+++ b/models/ReviewAnswer.ts
@@ -20,7 +20,7 @@ ReviewAnswer.init(
       type: DataTypes.STRING,
     },
   },
-  { sequelize, tableName: 'review_answer', timestamps: false }
+  { sequelize, tableName: 'review_answer' }
 );
 
 // Associations

--- a/models/ReviewHistory.ts
+++ b/models/ReviewHistory.ts
@@ -42,7 +42,7 @@ ReviewHistory.init(
       field: 'changed_by',
     },
   },
-  { sequelize, tableName: 'review_history', timestamps: false }
+  { sequelize, tableName: 'review_history' }
 );
 
 // Associations

--- a/models/ReviewPolicy.ts
+++ b/models/ReviewPolicy.ts
@@ -37,7 +37,7 @@ ReviewPolicy.init(
       allowNull: false,
     },
   },
-  { sequelize, tableName: 'review_policies', timestamps: false }
+  { sequelize, tableName: 'review_policies' }
 );
 
 // Associations

--- a/models/ReviewQuestion.ts
+++ b/models/ReviewQuestion.ts
@@ -36,7 +36,7 @@ ReviewQuestion.init(
       },
     },
   },
-  { sequelize, tableName: 'review_questions', timestamps: false }
+  { sequelize, tableName: 'review_questions' }
 );
 
 // Associations

--- a/models/ReviewStatus.ts
+++ b/models/ReviewStatus.ts
@@ -21,7 +21,6 @@ ReviewStatus.init(
   {
     sequelize,
     tableName: 'review_status',
-    timestamps: false,
   }
 );
 

--- a/models/ReviewType.ts
+++ b/models/ReviewType.ts
@@ -21,7 +21,6 @@ ReviewType.init(
   {
     sequelize,
     tableName: 'review_type',
-    timestamps: false,
   }
 );
 

--- a/models/User.ts
+++ b/models/User.ts
@@ -33,7 +33,6 @@ User.init(
   {
     sequelize,
     tableName: 'users',
-    timestamps: false,
   }
 );
 

--- a/models/UserProfile.ts
+++ b/models/UserProfile.ts
@@ -32,7 +32,6 @@ UserProfile.init(
   {
     sequelize,
     tableName: 'user_profiles',
-    timestamps: false,
   }
 );
 

--- a/models/UserRole.ts
+++ b/models/UserRole.ts
@@ -21,7 +21,6 @@ UserRole.init(
   {
     sequelize,
     tableName: 'user_roles',
-    timestamps: false,
   }
 );
 


### PR DESCRIPTION
Now, we should be able to keep track of the `createdAt` and `updatedAt` fields for _each_ table.