### PR TITLE
Update the Add Button to only show in Courses and Professors

### DIFF
--- a/app/admin/manage/page.tsx
+++ b/app/admin/manage/page.tsx
@@ -256,14 +256,14 @@ export default function Manage() {
         </Stack>
         {/* Conditionally render Add button only for 'courses' and 'professors' */}
         {selectedOption === 'courses' && (
-          <Link href="/admin/manage/course/add">
+          <Link href="/admin/manage/add-course">
             <Button as="a" colorScheme="teal" color="white" px={6}>
               Add
             </Button>
           </Link>
         )}
         {selectedOption === 'professors' && (
-          <Link href="/admin/manage/professor/add">
+          <Link href="/admin/manage/add-professor">
             <Button as="a" colorScheme="teal" color="white" px={6}>
               Add
             </Button>


### PR DESCRIPTION
## Update
- Add button in `app/admin/manage/page.tsx` so that only the Courses and Professors that are selected will show the Add Button for the Admin.
- the add-course route.

### Have Add button
![image](https://github.com/user-attachments/assets/3aefe1b0-3859-4098-b34e-132cd8a852d4)
![image](https://github.com/user-attachments/assets/1bbf0e77-81c7-4b54-b904-c2215edcb8fd)

### Have no Add button
![image](https://github.com/user-attachments/assets/afa2cf62-db69-4f93-96fa-9208d2b8e74e)
![image](https://github.com/user-attachments/assets/a8583d65-ef3a-4d23-8bfb-9b299c1147f9)

This pull request is part of issue #62
