### PR TITLE
Add the Edit Course Page for Admin

### DIFF
--- a/app/admin/manage/edit-course/[id]/page.tsx
+++ b/app/admin/manage/edit-course/[id]/page.tsx
@@ -1,0 +1,210 @@
+// app/admin/manage/edit-course/[id]/page.tsx
+'use client';
+
+import {
+  Box,
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Flex,
+  Heading,
+  Textarea,
+} from '@chakra-ui/react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState, useEffect } from 'react';
+import Select, { MultiValue } from 'react-select';
+
+// ************************************************** SAMPLE DATA TO BE REMOVED WHEN BACKEND FINISH **************************************************
+const sampleProfessors = [
+  { value: '1', label: 'Professor A' },
+  { value: '2', label: 'Professor B' },
+  { value: '3', label: 'Professor C' },
+  { value: '4', label: 'Professor D' },
+  { value: '5', label: 'Professor E' },
+  { value: '6', label: 'Professor F' },
+  { value: '7', label: 'Professor G' },
+];
+
+const sampleTerms = [
+  { value: 'Winter 2024', label: 'Winter 2024' },
+  { value: 'Summer 2024', label: 'Summer 2024' },
+  { value: 'Fall 2024', label: 'Fall 2024' },
+  { value: 'Winter 2025', label: 'Winter 2025' },
+  { value: 'Summer 2025', label: 'Summer 2025' },
+  { value: 'Fall 2025', label: 'Fall 2025' },
+];
+
+// ******************************************************************************************************************************************************************
+
+export default function EditCourse() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const courseId = searchParams.get('id');
+
+  const [selectedProfessors, setSelectedProfessors] = useState<{ value: string; label: string }[]>(
+    []
+  );
+  const [selectedTerm, setSelectedTerm] = useState('');
+  const [courseData, setCourseData] = useState({ name: '', section: '', description: '' });
+
+  useEffect(() => {
+    // Fetch the course data from the backend using courseId
+    const fetchCourseData = async () => {
+      const course = {
+        id: '1',
+        name: 'Course 1',
+        section: 'A',
+        description: 'Introductory course to programming.',
+        term: 'Fall 2024',
+        professors: [
+          { value: '1', label: 'John Doe' },
+          { value: '2', label: 'Jane Smith' },
+        ],
+      };
+      setCourseData(course);
+      setSelectedProfessors(course.professors);
+      setSelectedTerm(course.term);
+    };
+
+    fetchCourseData();
+  }, [courseId]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Handle the update course logic here
+    console.log({
+      ...courseData,
+      selectedProfessors,
+      selectedTerm,
+    });
+  };
+
+  const handleCancel = () => {
+    router.push('/admin/manage');
+  };
+
+  const handleProfessorChange = (newValue: MultiValue<{ value: string; label: string }>) => {
+    setSelectedProfessors(newValue as { value: string; label: string }[]);
+  };
+
+  return (
+    <Flex direction="column" align="center" justify="center" minHeight="100vh" bg="gray.50" p={5}>
+      <Box width={{ base: '90%', sm: '500px' }} borderRadius="lg" shadow="md" bg="white" p={8}>
+        <Heading as="h1" size="lg" mb={6} textAlign="center" color="teal">
+          Edit Course
+        </Heading>
+        <form onSubmit={handleSubmit}>
+          <Stack spacing={4}>
+            <FormControl>
+              <FormLabel htmlFor="course-name" color="black">
+                Course Name
+              </FormLabel>
+              <Input
+                value={courseData.name}
+                onChange={(e) => setCourseData({ ...courseData, name: e.target.value })}
+                required
+                color="black"
+                focusBorderColor="teal"
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel htmlFor="section-code" color="black">
+                Section Code
+              </FormLabel>
+              <Input
+                value={courseData.section}
+                onChange={(e) => setCourseData({ ...courseData, section: e.target.value })}
+                required
+                color="black"
+                focusBorderColor="teal"
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel htmlFor="professor-name" color="black">
+                Select Professors
+              </FormLabel>
+              <Select
+                isMulti
+                options={sampleProfessors}
+                value={selectedProfessors}
+                onChange={handleProfessorChange}
+                styles={customStyles}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel htmlFor="term" color="black">
+                Select Term
+              </FormLabel>
+              <Select
+                options={sampleTerms}
+                value={{ value: selectedTerm, label: selectedTerm }}
+                onChange={(option) => setSelectedTerm(option?.value || '')}
+                styles={customStyles}
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel htmlFor="description" color="black">
+                Description
+              </FormLabel>
+              <Textarea
+                value={courseData.description}
+                onChange={(e) => setCourseData({ ...courseData, description: e.target.value })}
+                required
+                color="black"
+                focusBorderColor="teal"
+              />
+            </FormControl>
+            <Button type="submit" colorScheme="teal" color="white">
+              Update Course
+            </Button>
+            <Button onClick={handleCancel} colorScheme="gray">
+              Cancel
+            </Button>
+          </Stack>
+        </form>
+      </Box>
+    </Flex>
+  );
+}
+
+// These customStyles would be similar in this page, add-professor, add-course and edit-professor pages
+// After all the page is complete and merge, I will return and refactor the customStyles to a separate file.
+const customStyles = {
+  control: (provided: any, { isFocused }: any) => ({
+    ...provided,
+    borderColor: isFocused ? 'teal' : 'gray.200',
+    borderWidth: isFocused ? '2px' : '1px',
+    boxShadow: 'none',
+    '&:hover': {
+      borderColor: isFocused ? 'teal' : 'gray.200',
+    },
+    minHeight: '40px',
+  }),
+  multiValue: (provided: any) => ({
+    ...provided,
+    backgroundColor: 'teal',
+  }),
+  multiValueLabel: (provided: any) => ({
+    ...provided,
+    color: 'white',
+  }),
+  multiValueRemove: (provided: any) => ({
+    ...provided,
+    color: 'white',
+    ':hover': {
+      backgroundColor: 'darkred',
+      color: 'white',
+    },
+  }),
+  option: (provided: any, { isSelected, isFocused }: any) => ({
+    ...provided,
+    backgroundColor: isSelected ? 'teal' : isFocused ? 'lightgray' : 'white',
+    color: isSelected ? 'white' : 'black',
+    ':active': {
+      backgroundColor: 'teal',
+      color: 'white',
+    },
+  }),
+};

--- a/app/admin/manage/page.tsx
+++ b/app/admin/manage/page.tsx
@@ -20,30 +20,35 @@ import ReviewsTable from '@/components/ReviewsTable';
 // ************************************************** SAMPLE DATA TO BE REMOVED WHEN BACKEND FINISH **************************************************
 const initialCourses = [
   {
+    id: '1',
     name: 'Course 1',
     section: 'A',
     term: 'Fall 2024',
     description: 'Introductory course to programming.',
   },
   {
+    id: '2',
     name: 'Course 2',
     section: 'B',
     term: 'Spring 2024',
     description: 'Advanced topics in software development.',
   },
   {
+    id: '3',
     name: 'Course 3',
     section: 'C',
     term: 'Winter 2024',
     description: 'Data Structures and Algorithms.',
   },
   {
+    id: '4',
     name: 'Course 4',
     section: 'D',
     term: 'Summer 2024',
     description: 'Web Development Fundamentals.',
   },
   {
+    id: '5',
     name: 'Course 5',
     section: 'A',
     term: 'Fall 2024',
@@ -51,12 +56,14 @@ const initialCourses = [
       'Introductory course to programming. This is a longer description that should be truncated if it exceeds the available space.',
   },
   {
+    id: '6',
     name: 'Course 6',
     section: 'B',
     term: 'Spring 2024',
     description: 'Advanced topics in software development.',
   },
   {
+    id: '7',
     name: 'Course 7',
     section: 'C',
     term: 'Winter 2024',

--- a/components/CoursesTable.tsx
+++ b/components/CoursesTable.tsx
@@ -1,8 +1,10 @@
 // components/CoursesTable.tsx
 import { Box, Flex, Stack, Text, Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
 
 // Define the Course type
 type Course = {
+  id: string;
   name: string;
   section: string;
   term: string;
@@ -17,7 +19,11 @@ interface CoursesTableProps {
 
 const CoursesTable: React.FC<CoursesTableProps> = ({ courses, onRemove }) => {
   // More logic would need to be added here to remove the course from the database
+  const router = useRouter();
 
+  const handleEditClick = (courseId: string) => {
+    router.push(`/admin/manage/edit-course/${courseId}`);
+  };
   return (
     <>
       {/* Table Header */}
@@ -98,6 +104,7 @@ const CoursesTable: React.FC<CoursesTableProps> = ({ courses, onRemove }) => {
                     flex="1"
                     mr={{ base: 0, md: 1 }}
                     mb={{ base: 1, md: 0 }}
+                    onClick={() => handleEditClick(course.id)}
                   >
                     Edit
                   </Button>


### PR DESCRIPTION
## Add
- Edit page for the Admin under `app/admin/manage/edit-page/page.tsx`.

## Update
- `CoursesTable` component to handle the route to the edit page.
- `app/admin/manage/page.tsx` to specify in the mock data the id.

This is what the current Edit Page for Admin looked like:
![image](https://github.com/user-attachments/assets/cf7cf627-c6f5-4972-890f-0d04d4214c4d)


This pull request is part of issue #62