### PR TITLE
Remove the Remove button in the Admin Manage Review

### DIFF
--- a/components/ReviewsTable.tsx
+++ b/components/ReviewsTable.tsx
@@ -1,3 +1,5 @@
+// components/ReviewsTable.tsx
+
 import { Box, Flex, Stack, Text, Button, Icon } from '@chakra-ui/react';
 import { FaCheckCircle, FaTimesCircle, FaExclamationCircle } from 'react-icons/fa';
 
@@ -133,9 +135,6 @@ const ReviewsTable: React.FC<ReviewsTableProps> = ({ reviews }) => {
                     mb={{ base: 1, md: 0 }}
                   >
                     View Details
-                  </Button>
-                  <Button colorScheme="teal" color="white" flex="1" ml={{ base: 0, md: 1 }}>
-                    Remove
                   </Button>
                 </Flex>
 


### PR DESCRIPTION
## Delete
- Remove Button in the Admin Manage Review which is from the `components/ReviewsTable.tsx` file. Admin cannot remove a review in this page. They can only view the details of the review.

This is what the page looks like now, with the `View Detail` button bigger
![image](https://github.com/user-attachments/assets/4210316b-bfca-47b9-b896-1beb5095f0e1)

This pull request is part of issue #62 
