### PR TITLE
Add the Admin Review Approval Page

### DIFF
--- a/app/admin/manage/get-review/[id]/page.tsx
+++ b/app/admin/manage/get-review/[id]/page.tsx
@@ -1,0 +1,167 @@
+// app/admin/manage/get-review/[id]/page.tsx
+
+'use client';
+import React, { useState, useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Box,
+  Button,
+  Flex,
+  FormControl,
+  FormLabel,
+  Heading,
+  Select,
+  Table,
+  Tbody,
+  Td,
+  Tr,
+  Text,
+} from '@chakra-ui/react';
+import ReviewsStatusIcon from '@/components/ReviewsStatusIcon';
+
+interface ReviewDetail {
+  question: string;
+  answer: string;
+}
+
+interface ReviewData {
+  id: string;
+  studentName: string;
+  studentEmail: string;
+  status: 'pending' | 'approved' | 'rejected';
+  reviewDetails: ReviewDetail[];
+}
+
+export default function ReviewDetails() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const reviewId = searchParams.get('id');
+
+  const [reviewData, setReviewData] = useState<ReviewData>({
+    id: '',
+    studentName: '',
+    studentEmail: '',
+    status: 'pending',
+    reviewDetails: [],
+  });
+
+  useEffect(() => {
+    // Fetch the review data from the backend using reviewId
+    const fetchReviewData = async () => {
+      // Simulated data fetch
+      const review: ReviewData = {
+        id: '123',
+        studentName: 'student_name',
+        studentEmail: 'student_email',
+        status: 'pending',
+        reviewDetails: [
+          { question: 'Title', answer: 'Too much course load' },
+          { question: 'Course Name', answer: 'CSP 555' },
+          { question: 'Term', answer: 'Winter 2023' },
+          { question: 'Course Section', answer: 'N/A' },
+          { question: 'Professor', answer: 'Henry Dunfield' },
+          { question: 'Worth Time Spent?', answer: 'No' },
+          { question: 'Difficulty', answer: '5/5' },
+          { question: 'Course Load', answer: '5/5' },
+          { question: 'Grade', answer: 'C+' },
+          {
+            question: 'Other Comments',
+            answer:
+              'The course content lacked depth and the materials were outdated, which hindered my learning experience.',
+          },
+        ],
+      };
+      setReviewData(review);
+    };
+
+    fetchReviewData();
+  }, [reviewId]);
+
+  const handleAccept = () => {
+    // Add logic to accept the review and update the status in the database
+    // Post Review to the backend
+    console.log('Review accepted');
+    router.back();
+  };
+
+  const handleReject = () => {
+    // Add logic to reject the review and update the status in the database
+    console.log('Review rejected');
+    router.back();
+  };
+
+  return (
+    <Flex direction={['column', 'row']} minHeight="auto" bg="gray.50" p={8} alignItems="flex-start">
+      {/* Left section: Review Details */}
+      <Box flex="2" borderRadius="lg" shadow="md" bg="white" p={8} mr={[0, 16]} mb={[8, 0]}>
+        <Flex justify="space-between" align="center" mb={4}>
+          <Heading as="h1" size="lg" mb={6} color="teal">
+            Review #{reviewData.id}
+          </Heading>
+          <Box mb={4}>
+            <ReviewsStatusIcon status={reviewData.status} />
+          </Box>
+        </Flex>
+        <Box mb={4}>
+          <Heading as="h2" size="md" mb={4} color="teal">
+            Student Information
+          </Heading>
+          <Text color="black">
+            <Box as="span" fontWeight="bold">
+              Name:{' '}
+            </Box>
+            {reviewData.studentName}
+          </Text>
+          <Text color="black">
+            <Box as="span" fontWeight="bold">
+              Email:{' '}
+            </Box>
+            {reviewData.studentEmail}
+          </Text>
+        </Box>
+        <Heading as="h2" size="md" mb={4} color="teal">
+          Review Details
+        </Heading>
+        <Table variant="simple">
+          <Tbody>
+            {reviewData.reviewDetails.map((review, index) => (
+              <Tr key={index}>
+                <Td color="black" fontWeight="bold">
+                  {review.question}
+                </Td>
+                <Td color="black">{review.answer}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </Box>
+
+      {/* Right section: Policy Violation and Buttons */}
+      <Flex direction="column" flex="1" maxWidth="400px" alignSelf="stretch">
+        <Box borderRadius="lg" shadow="md" bg="white" p={8} mb={8}>
+          <Heading as="h2" size="lg" mb={6} color="teal">
+            Policy Violation
+          </Heading>
+          <FormControl color="black" mb={6}>
+            <FormLabel>Select Type of Violation:</FormLabel>
+            <Select placeholder="Select violation type">
+              <option value="foul-language">Use of foul language</option>
+              <option value="plagiarism">Plagiarism</option>
+              <option value="harassment">Harassment</option>
+              <option value="cheating">Cheating</option>
+              <option value="other">Other</option>
+            </Select>
+          </FormControl>
+        </Box>
+        <Box mt="auto">
+          <Button colorScheme="green" onClick={handleAccept} width="full" mb={5} p={5} py={8}>
+            Accept Review
+          </Button>
+          <Button colorScheme="red" onClick={handleReject} width="full" p={5} py={8}>
+            Reject Review
+          </Button>
+        </Box>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/admin/manage/page.tsx
+++ b/app/admin/manage/page.tsx
@@ -127,6 +127,7 @@ const initialProfessors = [
 
 const reviews = [
   {
+    id: '1',
     category: 'Course Review',
     course_code: 'CSC101',
     review_text:
@@ -135,6 +136,7 @@ const reviews = [
     status: 'approved',
   },
   {
+    id: '2',
     category: 'Course Review',
     course_code: 'MTH202',
     review_text:
@@ -143,6 +145,7 @@ const reviews = [
     status: 'pending',
   },
   {
+    id: '3',
     category: 'Professor Review',
     course_code: 'PHY303',
     review_text:
@@ -151,6 +154,7 @@ const reviews = [
     status: 'approved',
   },
   {
+    id: '4',
     category: 'Course Review',
     course_code: 'ENG104',
     review_text:
@@ -159,6 +163,7 @@ const reviews = [
     status: 'rejected',
   },
   {
+    id: '5',
     category: 'Professor Review',
     course_code: 'CHE201',
     review_text:
@@ -167,6 +172,7 @@ const reviews = [
     status: 'pending',
   },
   {
+    id: '6',
     category: 'Course Review',
     course_code: 'CSC101',
     review_text:
@@ -175,6 +181,7 @@ const reviews = [
     status: 'approved',
   },
   {
+    id: '7',
     category: 'Course Review',
     course_code: 'MTH202',
     review_text:

--- a/components/ReviewsStatusIcon.tsx
+++ b/components/ReviewsStatusIcon.tsx
@@ -1,0 +1,21 @@
+import { Icon } from '@chakra-ui/react';
+import { FaCheckCircle, FaExclamationCircle, FaTimesCircle } from 'react-icons/fa';
+
+type StatusIconProps = {
+  status: 'approved' | 'pending' | 'rejected';
+};
+
+const ReviewsStatusIcon: React.FC<StatusIconProps> = ({ status }) => {
+  switch (status) {
+    case 'approved':
+      return <Icon as={FaCheckCircle} color="green.500" boxSize="8" />;
+    case 'pending':
+      return <Icon as={FaExclamationCircle} color="yellow.500" boxSize="8" />;
+    case 'rejected':
+      return <Icon as={FaTimesCircle} color="red.500" boxSize="8" />;
+    default:
+      return null;
+  }
+};
+
+export default ReviewsStatusIcon;

--- a/components/ReviewsTable.tsx
+++ b/components/ReviewsTable.tsx
@@ -1,10 +1,10 @@
-// components/ReviewsTable.tsx
-
-import { Box, Flex, Stack, Text, Button, Icon } from '@chakra-ui/react';
-import { FaCheckCircle, FaTimesCircle, FaExclamationCircle } from 'react-icons/fa';
+import { Box, Flex, Stack, Text, Button } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
+import ReviewsStatusIcon from './ReviewsStatusIcon';
 
 // Define the Review type
 type Review = {
+  id: string;
   category: string;
   course_code: string;
   review_text: string;
@@ -18,6 +18,7 @@ interface ReviewsTableProps {
 }
 
 const ReviewsTable: React.FC<ReviewsTableProps> = ({ reviews }) => {
+  const router = useRouter();
   // Sort reviews by status ('pending' first)
   const sortedReviews = [...reviews].sort((a, b) => {
     if (a.status === 'pending' && b.status !== 'pending') return -1;
@@ -27,18 +28,8 @@ const ReviewsTable: React.FC<ReviewsTableProps> = ({ reviews }) => {
     return b.average_rate - a.average_rate;
   });
 
-  // Function to get the correct status icon
-  const getStatusIcon = (status: string) => {
-    switch (status) {
-      case 'approved':
-        return <Icon as={FaCheckCircle} color="green.500" boxSize="8" />;
-      case 'pending':
-        return <Icon as={FaExclamationCircle} color="yellow.500" boxSize="8" />;
-      case 'rejected':
-        return <Icon as={FaTimesCircle} color="red.500" boxSize="8" />;
-      default:
-        return null;
-    }
+  const handleViewDetailsClick = (reviewId: string) => {
+    router.push(`/admin/manage/get-review/${reviewId}`);
   };
 
   return (
@@ -133,14 +124,17 @@ const ReviewsTable: React.FC<ReviewsTableProps> = ({ reviews }) => {
                     flex="1"
                     mr={{ base: 0, md: 1 }}
                     mb={{ base: 1, md: 0 }}
+                    onClick={() => handleViewDetailsClick(review.id)}
                   >
                     View Details
                   </Button>
                 </Flex>
 
                 {/* Status Icon */}
-                <Text flex="1" textAlign="center" m={1}>
-                  {getStatusIcon(review.status)}
+                <Text flex="1" textAlign="center" ml={5}>
+                  <ReviewsStatusIcon
+                    status={review.status as 'approved' | 'pending' | 'rejected'}
+                  />
                 </Text>
               </Flex>
             </Box>


### PR DESCRIPTION
## Add
- Admin Approval Review Page under `app/admin/manage/get-review/[id]/page.tsx`
- ReviewsStatusIcon component under `components/ReviewsStatusIcon.tsx`. This component would also be needed in the user profile menu `Reviews > Courses` and `Reviews > Professors`.

## Update
- `app/admin/manage/page.tsx` to add id in my mock data
- `components/ReviewsTable.tsx` for it to use the ReviewsStatusIcon component and change the View Details button route.

This is what the page looks like:
![image](https://github.com/user-attachments/assets/118ebb2b-6c7f-4a03-95c1-cf335543b88f)

This pull request is related to issues #62 and #63.
