### PR TITLE
Create the User Profile Menu and Reviews Submenu

### DIFF
--- a/components/Navbar/MainNav.tsx
+++ b/components/Navbar/MainNav.tsx
@@ -275,6 +275,9 @@ export default function MainNav(props: { user: any }) {
                       Bookmark
                     </MenuItem>
                     {/* End of ELSE Logic */}
+                    <MenuItem as="a" href="/user/sap">
+                      Settings & Privacy
+                    </MenuItem>
                   </MenuGroup>
                   <MenuDivider />
                   <MenuItem as="a" href="/api/auth/logout">


### PR DESCRIPTION
## Update
- MainNav component under components/Navbar/MainNav.tsx to have the user profile menu and reviews submenu. We currently also see the Manage of Admin menu. However, this would be changed when we can fetch our Admin user role from the database.

Currently, the Profile Menu looks like this:
![image](https://github.com/user-attachments/assets/6a9322c7-63e8-40f7-9db4-f1accbd3f50d)

This pull request is related to issue #50 and #69