### PR TITLE
fix: capitalize the courseCode received from the queryParams

### DIFF
--- a/app/courses/[courseCode]/page.tsx
+++ b/app/courses/[courseCode]/page.tsx
@@ -66,13 +66,14 @@ function getURL(
     url = `/api/${apiRoute}/${courseCode}?season=${season}`;
   } else {
     url = `/api/${apiRoute}/${courseCode}`;
+    console.log('here');
   }
 
   return url;
 }
 
 export default function CoursePage({ params }: { params: { courseCode: string } }) {
-  const courseCode = params.courseCode;
+  const courseCode = params.courseCode.toUpperCase();
   const [expandedReviewId, setExpandedReviewId] = useState(-1);
   const [course, setCourse] = useState<ICourse | null>(null);
   const [reviews, setReviews]: any = useState(null);


### PR DESCRIPTION
This should fix the issue where our browsers forcibly change the courseCode into lowercase.