### PR TITLE
chore: get .eslintrc.json and .prettierignore to ignore certain folders/files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,18 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "ignorePatterns": [
+    "node_modules/**",
+    "package.json",
+    "package-lock.json",
+    "_documents/**",
+    ".github/**",
+    ".husky/**",
+    ".next/**",
+    "assets/**",
+    "miscellaneous/**",
+    "public/**",
+    "_examples/**",
+    ".git/**",
+    "coverage/**"
+  ]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,13 @@
 node_modules/
 package.json
 package-lock.json
+_documents/
+.github/
+.husky/
+.next/
+assets/
+miscellaneous/
+public/
+_examples/
+.git/
+coverage/


### PR DESCRIPTION
This change should greatly reduce the time it takes to run the `pre-commit` hook, which formats and lints our code.

Previously, the linter and formatter was looking at all of the source code (e.g., node_modules, or the .next folder).

This has since been fixed in this pull request.

