### PR TITLE
fix: remove page and limit from courses and professors API routes

### DIFF
--- a/app/api/courses/route.ts
+++ b/app/api/courses/route.ts
@@ -20,28 +20,28 @@ export const GET = withApiAuthRequired(async function get_courses(
     await connectDB();
     const url = new URL(req.url);
 
-    const queryParams: { page: string; limit: string } = {
-      page: url.searchParams.get('page') || '1',
-      limit: url.searchParams.get('limit') || '10',
-    };
+    // const queryParams: { page: string; limit: string } = {
+    //   page: url.searchParams.get('page') || '1',
+    //   limit: url.searchParams.get('limit') || '10',
+    // };
 
     // Ref Doc: https://www.shecodes.io/athena/60744-what-is-parseint-in-javascript#
-    const pageNumber: number = parseInt(queryParams.page, 10);
-    const limit: number = parseInt(queryParams.limit, 10);
+    // const pageNumber: number = parseInt(queryParams.page, 10);
+    // const limit: number = parseInt(queryParams.limit, 10);
 
     // Validate pagination parameters
-    if (isNaN(pageNumber) || isNaN(limit) || pageNumber < 1 || limit < 1) {
-      log.error('Invalid pagination parameters', { pageNumber, limit });
-      return NextResponse.json(createErrorResponse(400, 'Invalid pagination parameters'), {
-        status: 400,
-      });
-    }
+    // if (isNaN(pageNumber) || isNaN(limit) || pageNumber < 1 || limit < 1) {
+    //   log.error('Invalid pagination parameters', { pageNumber, limit });
+    //   return NextResponse.json(createErrorResponse(400, 'Invalid pagination parameters'), {
+    //     status: 400,
+    //   });
+    // }
 
-    log.info('Fetching courses', { pageNumber, limit });
+    // log.info('Fetching courses', { pageNumber, limit });
 
     const { count: totalCourses, rows: courses } = await Course.findAndCountAll({
-      offset: (pageNumber - 1) * limit,
-      limit,
+      // offset: (pageNumber - 1) * limit,
+      // limit,
       order: [['course_code', 'ASC']],
       include: [
         {
@@ -59,13 +59,13 @@ export const GET = withApiAuthRequired(async function get_courses(
       ],
     });
 
-    const totalPages = Math.ceil(totalCourses / limit);
+    // const totalPages = Math.ceil(totalCourses / limit);
 
     log.debug(
       {
         courses,
-        totalPages,
-        currentPage: pageNumber,
+        // totalPages,
+        // currentPage: pageNumber,
         totalCourses,
       },
       'Courses fetched from DB'
@@ -76,8 +76,8 @@ export const GET = withApiAuthRequired(async function get_courses(
     return NextResponse.json(
       createSuccessResponse({
         courses,
-        totalPages,
-        currentPage: pageNumber,
+        // totalPages,
+        // currentPage: pageNumber,
         totalCourses,
       }),
       { status: 200 }

--- a/app/api/professors/route.ts
+++ b/app/api/professors/route.ts
@@ -26,51 +26,54 @@ export const GET = async function get_professors(req: NextRequest): Promise<Next
     };
 
     // Ref Doc: https://www.shecodes.io/athena/60744-what-is-parseint-in-javascript#
-    const pageNumber: number = parseInt(queryParams.page, 10);
-    const limitNumber: number = parseInt(queryParams.limit, 10);
+    // const pageNumber: number = parseInt(queryParams.page, 10);
+    // const limitNumber: number = parseInt(queryParams.limit, 10);
 
     // Validate pagination parameters
-    if (isNaN(pageNumber) || isNaN(limitNumber) || pageNumber < 1 || limitNumber < 1) {
-      log.error('Invalid pagination parameters', { pageNumber, limitNumber });
-      return NextResponse.json(createErrorResponse(400, 'Invalid pagination parameters'), {
-        status: 400,
-      });
-    }
+    // if (isNaN(pageNumber) || isNaN(limitNumber) || pageNumber < 1 || limitNumber < 1) {
+    //   log.error('Invalid pagination parameters', { pageNumber, limitNumber });
+    //   return NextResponse.json(createErrorResponse(400, 'Invalid pagination parameters'), {
+    //     status: 400,
+    //   });
+    // }
 
     // Calculate the number of documents to skip
-    const offsetNumber: number = (pageNumber - 1) * limitNumber;
+    // const offsetNumber: number = (pageNumber - 1) * limitNumber;
 
-    log.info('Fetching professors', { pageNumber, limitNumber });
+    // log.info('Fetching professors', { pageNumber, limitNumber });
 
     // Fetch the professors and count the total number of records
-    const professors = await Professor.findAll({ limit: limitNumber, offset: offsetNumber });
+    const professors = await Professor.findAll({
+      // limit: limitNumber,
+      // offset: offsetNumber
+    });
 
     console.log(professors);
 
     const totalProfessors: number = await Professor.count();
-    const totalPages: number = Math.ceil(totalProfessors / limitNumber);
+    // const totalPages: number = Math.ceil(totalProfessors / limitNumber);
 
     log.debug(
       {
         professors,
-        totalPages,
-        currentPage: pageNumber,
+        // totalPages,
+        // currentPage: pageNumber,
         totalProfessors,
       },
       'Professors fetched from DB'
     );
 
     log.info('Professors fetched successfully', {
-      totalPages,
-      currentPage: pageNumber,
+      // totalPages,
+      // currentPage: pageNumber,
       totalProfessors,
     });
 
     return NextResponse.json(
       createSuccessResponse({
         professors,
-        totalPages,
-        currentPage: pageNumber,
+        // totalPages,
+        // currentPage: pageNumber,
         totalProfessors,
       }),
       { status: 200 }


### PR DESCRIPTION
Fixes #140.

The pagination adds unneeded complexity at the moment. Removing it from the courses and professors API for now so the frontend can get all the results back.

The code responsible for pagination is left there (as comments), in case we do want to use it in the future.

Below is an image showing that we can retrieve more courses than before (after tweaking the frontend a bit):

![image](https://github.com/user-attachments/assets/775a4db7-a582-4997-a64a-72e4e46fb7cf)

