### PR TITLE
build: remove version from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 # Docker Compose configuration for setting up a local testing environment.
 # This includes a PostgreSQL database and Adminer for database management.
 
-version: '3.1'
-
 networks:
   development-network:
     driver: bridge


### PR DESCRIPTION
Fixes #146.

Now, if the user uses `npm run stop` or `docker compose down`, there shouldn't be an extra log message.

![image](https://github.com/user-attachments/assets/b6d33e30-fd76-4a64-b278-03676712da60)
