### PR TITLE
feat: add /professors/[professordId] DELETE route

### DIFF
--- a/app/api/professors/[professorId]/route.ts
+++ b/app/api/professors/[professorId]/route.ts
@@ -1,0 +1,42 @@
+// app/api/professors/[professorId]/route.ts
+
+import { NextResponse, NextRequest } from 'next/server';
+import { connectDB } from '@/database/connectDB';
+import { createSuccessResponse, createErrorResponse } from '@/utils';
+import Professor from '@/database/models/Professor';
+import { logger } from '@/utils';
+import { withApiAuthRequired } from '@auth0/nextjs-auth0';
+
+export const DELETE = withApiAuthRequired(async function delete_professor_by_professor_id(
+  req: NextRequest
+): Promise<NextResponse> {
+  const log = logger.child({ module: 'app/api/professors/[professorId]/route.ts' });
+
+  try {
+    await connectDB();
+    const url = new URL(req.url);
+
+    const professorId = url.pathname.split('/').pop();
+
+    const professor = await Professor.findByPk(professorId);
+
+    if (!professor) {
+      log.warn('Professor not found', { professorId });
+      return NextResponse.json(createErrorResponse(404, 'Professor not found'), { status: 404 });
+    }
+
+    await professor.destroy();
+
+    log.info('Professor deleted successfully', { professorId });
+    return NextResponse.json(createSuccessResponse({ message: 'Professor deleted successfully' }), {
+      status: 200,
+    });
+  } catch (error: unknown) {
+    console.error(error);
+    log.error('Error deleting professor by professorId', { error });
+    return NextResponse.json(
+      createErrorResponse(500, 'Something went wrong. A server-side issue occurred.'),
+      { status: 500 }
+    );
+  }
+});


### PR DESCRIPTION
# Please don't merge yet

Still a WIP, but attempts to close #148.

Was hoping for suggestions on how to handle any child records associated with the Professor (e.g., `ProfessorCourse`).

To start testing this, do the following in sequence:

1. Add yourself as an admin, by going to `database/seedDB/seedUsers.ts` and giving yourself a  `role_id` of 1.
   
![image](https://github.com/user-attachments/assets/0675a4c6-7166-47a5-a583-40565de1a868)

2. Then, run `docker compose up --build`.
3. Then, run `npm run dev`.
4. On your browser, go to `http://localhost:3000/admin/manage?option=professors`. With our current data, you should see 5 professors:
		
![image-2](https://github.com/user-attachments/assets/3c06b4ab-93b6-48bf-a5c5-70881ca187fe)

6.  Try clicking the `Remove` button beside one of the professors. Certain will be deleted from the database, presumably because they don't have any child records. Other professors aren't deleted because they have child records
7.  NOTE: the frontend isn't updating in real time to reflect changes to the professors table (i.e., you need to refresh the page to see the professors deleted).
