### PR TITLE
Add the Delete Professor Logic

### DIFF
--- a/app/admin/manage/page.tsx
+++ b/app/admin/manage/page.tsx
@@ -17,7 +17,7 @@ import CoursesTable from '@/components/CoursesTable';
 import ProfessorsTable from '@/components/ProfessorsTable';
 import ReviewsTable from '@/components/ReviewsTable';
 import withAdminAuth from '@/components/withAdminAuth';
-import useSWR from 'swr';
+import useSWR, { mutate } from 'swr';
 import { apiFetcher } from '@/utils';
 
 export default withAdminAuth(function Manage({ user }: { user: any }) {
@@ -60,6 +60,7 @@ export default withAdminAuth(function Manage({ user }: { user: any }) {
       }
 
       // Optionally, you can trigger a refetch or update state here to refresh the data
+      mutate('/api/professors');
     } catch (error) {
       console.error('Error removing professor:', error);
     }

--- a/components/ProfessorsTable.tsx
+++ b/components/ProfessorsTable.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/navigation';
 import useSWR from 'swr';
 import { apiFetcher } from '@/utils';
 
-const ProfessorsTable: React.FC<{ professors: any[]; onRemove: (index: number) => void }> = ({
+const ProfessorsTable: React.FC<{ professors: any[]; onRemove: (professorId: number) => void }> = ({
   professors,
   onRemove,
 }) => {


### PR DESCRIPTION
## Update
- Delete Professor logic to the Admin side.

Only Professors that do not have any child or reviews about them can be deleted. The frontend has also been fixed so that it show the result right away instead of having to refresh the page to see the deleted professor.

This is how it would look like when I delete the fifth professor that has no child data.
![image](https://github.com/user-attachments/assets/63c93941-0ea6-44e0-953f-0158c165d285)

Made sure the backend professor is also deleted.
![image](https://github.com/user-attachments/assets/6f13fa5b-6348-4472-9207-2410cdca1e67)


This pull request is a progress to issue #52 