### PR TITLE
Change to use Link element from next/link

### DIFF
--- a/components/Footer/MainFooter.tsx
+++ b/components/Footer/MainFooter.tsx
@@ -1,9 +1,10 @@
 // components/Footer/MainFooter.tsx
 'use client';
-import { Box, Container, Text, Flex, Link, IconButton, useColorModeValue } from '@chakra-ui/react';
+import { Box, Container, Text, Flex, IconButton, useColorModeValue } from '@chakra-ui/react';
 import { FaFacebook, FaGithub, FaXTwitter, FaLinkedin, FaInstagram } from 'react-icons/fa6';
 import React from 'react';
 import { useFlexStyle } from '@/styles/styles';
+import Link from 'next/link';
 
 export default function MainFooter() {
   const flexStyle = useFlexStyle();
@@ -29,18 +30,10 @@ export default function MainFooter() {
             align={{ base: 'center', md: 'flex-start' }}
             textAlign={{ base: 'center', md: 'left' }}
           >
-            <Link href="/about" mb={{ base: 2, md: 0 }}>
-              About
-            </Link>
-            <Link href="/contact" mb={{ base: 2, md: 0 }}>
-              Contact Us
-            </Link>
-            <Link href="/faq" mb={{ base: 2, md: 0 }}>
-              FAQ
-            </Link>
-            <Link href="/terms" mb={{ base: 2, md: 0 }}>
-              Terms & Conditions
-            </Link>
+            <Link href="/">Home</Link>
+            <Link href="/about">About</Link>
+            <Link href="/contact">Contact Us</Link>
+            <Link href="/faq">FAQ</Link>
           </Flex>
 
           {/* Social Media Icons Section */}


### PR DESCRIPTION
## Update
- MainFooter.tsx to use `Link` from `next/link` instead of `chakra-ui/react` due to some loading inconsistency, where when once one of the Footer links is selected it would flash from light mode to dark mode when we are in dark mode. Now it would no longer flash from light mode and just stay in the dark mode

## Remove
- I removed the Term & Condition link because I don't think we would be creating one .

## Add
- Instead of the Term & Condition link I added the Home page link. So it is the same link in the navbar and the footer.

This pull request work on issue #56 and #177