### PR TITLE
Remove the Setting and Privacy from the Profile Menu

### DIFF
--- a/components/Navbar/MainNav.tsx
+++ b/components/Navbar/MainNav.tsx
@@ -391,9 +391,6 @@ export default function MainNav(props: { user: any }) {
                       </>
                     )}
                     {/* End of ELSE Logic */}
-                    <MenuItem as="a" href="/user/sap">
-                      Settings & Privacy
-                    </MenuItem>
                   </MenuGroup>
                   <MenuDivider />
                   <MenuItem as="a" href="/api/auth/logout">


### PR DESCRIPTION
## Remove
- Setting & Privacy from the Profile MEnu since it used to be for the light and dark mode but we have no implemented the toggle icon directly on the navbar.

![image](https://github.com/user-attachments/assets/f94f33dc-305f-4155-bf69-a1ae667b70d2)
![image](https://github.com/user-attachments/assets/cc91067e-6f42-4eaf-915f-cb697405bd2c)
