### PR TITLE
styles: add prettier devDependency & sync .prettierrc & settings.json

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -6,6 +6,7 @@
   "insertPragma": false,
   "proseWrap": "preserve",
   "requirePragma": false,
+  "jsxSingleQuote": false,
   "singleQuote": true,
   "tabWidth": 2,
   "trailingComma": "es5",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,22 +1,22 @@
 {
-  "editor.insertSpaces": true,
-  "editor.tabSize": 2,
+  "prettier.arrowParens": "always",
+  "prettier.bracketSpacing": true,
+  "prettier.embeddedLanguageFormatting": "auto",
+  "prettier.endOfLine": "lf",
+  "prettier.insertPragma": false,
+  "prettier.proseWrap": "preserve",
+  "prettier.requirePragma": false,
+  "prettier.jsxSingleQuote": false,
+  "prettier.singleQuote": true,
+  "prettier.tabWidth": 2,
+  "prettier.trailingComma": "es5",
+  "prettier.useTabs": false,
+  "prettier.printWidth": 100,
   "editor.detectIndentation": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
   },
-  "files.eol": "\n",
-  "files.insertFinalNewline": true,
-  "prettier.jsxSingleQuote": true,
-  "prettier.singleQuote": true,
-  "typescript.preferences.quoteStyle": "single",
-  "javascript.preferences.quoteStyle": "single",
-  "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
-  }
+  "files.insertFinalNewline": true
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "eslint-config-next": "14.2.3",
         "husky": "^9.1.6",
         "postcss": "^8",
+        "prettier": "^3.3.3",
         "tailwindcss": "^3.4.1",
         "ts-node": "^10.9.2",
         "types": "^0.1.1",
@@ -9034,6 +9035,22 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint-config-next": "14.2.3",
     "husky": "^9.1.6",
     "postcss": "^8",
+    "prettier": "^3.3.3",
     "tailwindcss": "^3.4.1",
     "ts-node": "^10.9.2",
     "types": "^0.1.1",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Feature
- [ ] Fix
- [x] Bug Fix
- [ ] Refactor
- [ ] Documentation Update

## Related Issues & Documents

- Related Issue: #56 
- Closes #265 

## Description

This pull request ensures that there's no more mismatch between the formatting done by the pre-commit hook and npm run format vs. what is done by VSCode when we save a file.

## IMPORTANT:

- please run `npm i` after merging the changes from this PR

